### PR TITLE
accurate-validation-error-response-with-drf-spectacular

### DIFF
--- a/drf_standardized_errors/openapi_hooks.py
+++ b/drf_standardized_errors/openapi_hooks.py
@@ -1,0 +1,173 @@
+import re
+from collections import defaultdict
+
+from drf_spectacular.plumbing import (
+    ResolvedComponent,
+    list_hash,
+    load_enum_name_overrides,
+    safe_ref,
+    warn,
+)
+from drf_spectacular.settings import spectacular_settings
+from inflection import camelize
+
+from .settings import package_settings
+
+
+def postprocess_schema_enums(result, generator, **kwargs):
+    """
+    This a copy of the postprocessing hook for enums provided by drf-spectacular
+    with only one change in `iter_prop_containers`. The change allows excluding
+    components that have a certain suffix from enum component auto-generation.
+    This excludes certain validation error components from postprocessing.
+    The excluded enum components are for dynamically created error serializers
+    where "attr" and "code" fields might have the same choices across multiple
+    serializers.
+
+    simple replacement of Enum/Choices that globally share the same name and have
+    the same choices. Aids client generation to not generate a separate enum for
+    every occurrence. only takes effect when replacement is guaranteed to be correct.
+    """
+
+    def iter_prop_containers(schema, component_name=None):
+        if not component_name:
+            for component_name, schema in schema.items():
+                if spectacular_settings.COMPONENT_SPLIT_PATCH:
+                    component_name = re.sub("^Patched(.+)", r"\1", component_name)
+                if spectacular_settings.COMPONENT_SPLIT_REQUEST:
+                    component_name = re.sub("(.+)Request$", r"\1", component_name)
+                yield from iter_prop_containers(schema, component_name)
+        elif isinstance(schema, list):
+            for item in schema:
+                yield from iter_prop_containers(item, component_name)
+        elif isinstance(schema, dict):
+            # This is the only change made:
+            # exclude error components from postprocessing. That's because the
+            # components are for dynamically created error serializers where
+            # "attr" and "code" fields might have the same choices across
+            # multiple serializers.
+            suffix = package_settings.ERROR_COMPONENT_NAME_SUFFIX
+            if schema.get("properties") and not component_name.endswith(suffix):
+                yield component_name, schema["properties"]
+            yield from iter_prop_containers(schema.get("oneOf", []), component_name)
+            yield from iter_prop_containers(schema.get("allOf", []), component_name)
+            yield from iter_prop_containers(schema.get("anyOf", []), component_name)
+
+    def create_enum_component(name, schema):
+        component = ResolvedComponent(
+            name=name, type=ResolvedComponent.SCHEMA, schema=schema, object=name
+        )
+        generator.registry.register_on_missing(component)
+        return component
+
+    schemas = result.get("components", {}).get("schemas", {})
+
+    overrides = load_enum_name_overrides()
+
+    prop_hash_mapping = defaultdict(set)
+    hash_name_mapping = defaultdict(set)
+    # collect all enums, their names and choice sets
+    for component_name, props in iter_prop_containers(schemas):
+        for prop_name, prop_schema in props.items():
+            if prop_schema.get("type") == "array":
+                prop_schema = prop_schema.get("items", {})
+            if "enum" not in prop_schema:
+                continue
+            # remove blank/null entry for hashing. will be reconstructed in the last step
+            prop_enum_cleaned_hash = list_hash(
+                [i for i in prop_schema["enum"] if i not in ["", None]]
+            )
+            prop_hash_mapping[prop_name].add(prop_enum_cleaned_hash)
+            hash_name_mapping[prop_enum_cleaned_hash].add((component_name, prop_name))
+
+    # traverse all enum properties and generate a name for the choice set. naming collisions
+    # are resolved and a warning is emitted. giving a choice set multiple names is technically
+    # correct but potentially unwanted. also emit a warning there to make the user aware.
+    enum_name_mapping = {}
+    for prop_name, prop_hash_set in prop_hash_mapping.items():
+        for prop_hash in prop_hash_set:
+            if prop_hash in overrides:
+                enum_name = overrides[prop_hash]
+            elif len(prop_hash_set) == 1:
+                # prop_name has been used exclusively for one choice set (best case)
+                enum_name = f"{camelize(prop_name)}Enum"
+            elif len(hash_name_mapping[prop_hash]) == 1:
+                # prop_name has multiple choice sets, but each one limited to one component only
+                component_name, _ = next(iter(hash_name_mapping[prop_hash]))
+                enum_name = f"{camelize(component_name)}{camelize(prop_name)}Enum"
+            else:
+                enum_name = f"{camelize(prop_name)}{prop_hash[:3].capitalize()}Enum"
+                warn(
+                    f"enum naming encountered a non-optimally resolvable collision for fields "
+                    f'named "{prop_name}". The same name has been used for multiple choice sets '
+                    f'in multiple components. The collision was resolved with "{enum_name}". '
+                    f"add an entry to ENUM_NAME_OVERRIDES to fix the naming."
+                )
+            if enum_name_mapping.get(prop_hash, enum_name) != enum_name:
+                warn(
+                    f"encountered multiple names for the same choice set ({enum_name}). This "
+                    f"may be unwanted even though the generated schema is technically correct. "
+                    f"Add an entry to ENUM_NAME_OVERRIDES to fix the naming."
+                )
+                del enum_name_mapping[prop_hash]
+            else:
+                enum_name_mapping[prop_hash] = enum_name
+            enum_name_mapping[(prop_hash, prop_name)] = enum_name
+
+    # replace all enum occurrences with a enum schema component. cut out the
+    # enum, replace it with a reference and add a corresponding component.
+    for _, props in iter_prop_containers(schemas):
+        for prop_name, prop_schema in props.items():
+            is_array = prop_schema.get("type") == "array"
+            if is_array:
+                prop_schema = prop_schema.get("items", {})
+
+            if "enum" not in prop_schema:
+                continue
+
+            prop_enum_original_list = prop_schema["enum"]
+            prop_schema["enum"] = [
+                i for i in prop_schema["enum"] if i not in ["", None]
+            ]
+            prop_hash = list_hash(prop_schema["enum"])
+            # when choice sets are reused under multiple names, the generated name cannot be
+            # resolved from the hash alone. fall back to prop_name and hash for resolution.
+            enum_name = (
+                enum_name_mapping.get(prop_hash)
+                or enum_name_mapping[prop_hash, prop_name]
+            )
+
+            # split property into remaining property and enum component parts
+            enum_schema = {
+                k: v for k, v in prop_schema.items() if k in ["type", "enum"]
+            }
+            prop_schema = {
+                k: v for k, v in prop_schema.items() if k not in ["type", "enum"]
+            }
+
+            components = [create_enum_component(enum_name, schema=enum_schema)]
+            if spectacular_settings.ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE:
+                if "" in prop_enum_original_list:
+                    components.append(
+                        create_enum_component("BlankEnum", schema={"enum": [""]})
+                    )
+                if None in prop_enum_original_list:
+                    components.append(
+                        create_enum_component("NullEnum", schema={"enum": [None]})
+                    )
+
+            if len(components) == 1:
+                prop_schema.update(components[0].ref)
+            else:
+                prop_schema.update({"oneOf": [c.ref for c in components]})
+
+            if is_array:
+                props[prop_name]["items"] = safe_ref(prop_schema)
+            else:
+                props[prop_name] = safe_ref(prop_schema)
+
+    # sort again with additional components
+    result["components"] = generator.registry.build(
+        spectacular_settings.APPEND_COMPONENTS
+    )
+    return result

--- a/drf_standardized_errors/openapi_utils.py
+++ b/drf_standardized_errors/openapi_utils.py
@@ -418,8 +418,12 @@ def get_error_serializer(
 ) -> Type[serializers.Serializer]:
     attr_choices = [(attr, attr)]
     error_code_choices = sorted(zip(error_codes, error_codes))
+
+    camelcase_operation_id = camelize(operation_id)
     attr_with_underscores = attr.replace(package_settings.NESTED_FIELD_SEPARATOR, "_")
-    component_name = f"{camelize(operation_id)}{camelize(attr_with_underscores)}Error"
+    camelcase_attr = camelize(attr_with_underscores)
+    suffix = package_settings.ERROR_COMPONENT_NAME_SUFFIX
+    component_name = f"{camelcase_operation_id}{camelcase_attr}{suffix}"
 
     class ErrorSerializer(serializers.Serializer):
         attr = serializers.ChoiceField(choices=attr_choices)

--- a/drf_standardized_errors/openapi_utils.py
+++ b/drf_standardized_errors/openapi_utils.py
@@ -1,0 +1,489 @@
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import List, Optional, Set, Type, Union
+
+from django import forms
+from django.core.validators import (
+    DecimalValidator,
+    EmailValidator,
+    FileExtensionValidator,
+    MaxLengthValidator,
+    MaxValueValidator,
+    MinLengthValidator,
+    MinValueValidator,
+    ProhibitNullCharactersValidator,
+    RegexValidator,
+    validate_ipv4_address,
+    validate_ipv6_address,
+    validate_ipv46_address,
+)
+from drf_spectacular.plumbing import (
+    force_instance,
+    get_view_model,
+    is_basic_serializer,
+    is_list_serializer,
+    is_serializer,
+)
+from drf_spectacular.utils import OpenApiExample, PolymorphicProxySerializer
+from inflection import camelize
+from rest_framework import exceptions, serializers
+from rest_framework.settings import api_settings as drf_settings
+from rest_framework.status import is_client_error
+from rest_framework.validators import (
+    BaseUniqueForValidator,
+    ProhibitSurrogateCharactersValidator,
+    UniqueTogetherValidator,
+    UniqueValidator,
+)
+from rest_framework.views import APIView
+
+from .openapi_serializers import ValidationErrorEnum
+from .settings import package_settings
+
+
+def get_flat_serializer_fields(
+    field: Union[serializers.Field, List[serializers.Field]], prefix: str = None
+) -> "List[InputDataField]":
+    """
+    return a flat list of serializer fields. The fields list will later be used
+    to identify error codes that can be raised by each field. So, it contains
+    at least one field representing "non field errors" and accounts properly
+    for composite fields by returning 2 fields: one for the errors linked to
+    the parent field and another one for errors linked to the child field.
+    """
+    if not field:
+        return []
+
+    field = force_instance(field)
+    if is_list_serializer(field):
+        prefix = get_prefix(prefix, package_settings.LIST_INDEX_IN_API_SCHEMA)
+        non_field_errors_name = get_prefix(prefix, drf_settings.NON_FIELD_ERRORS_KEY)
+        f = InputDataField(non_field_errors_name, field)
+        return [f] + get_flat_serializer_fields(field.child, prefix)
+    elif is_serializer(field):
+        prefix = get_prefix(prefix, field.field_name)
+        non_field_errors_name = get_prefix(prefix, drf_settings.NON_FIELD_ERRORS_KEY)
+        f = InputDataField(non_field_errors_name, field)
+        return [f] + get_flat_serializer_fields(list(field.fields.values()), prefix)
+    elif isinstance(field, list):
+        first, *remaining = field
+        return get_flat_serializer_fields(first, prefix) + get_flat_serializer_fields(
+            remaining, prefix
+        )
+    elif hasattr(field, "child"):
+        # composite field (List or Dict fields)
+        prefix = get_prefix(prefix, field.field_name)
+        f = InputDataField(prefix, field)
+        if isinstance(field, serializers.ListField):
+            child_prefix = get_prefix(prefix, package_settings.LIST_INDEX_IN_API_SCHEMA)
+        else:
+            child_prefix = get_prefix(prefix, package_settings.DICT_KEY_IN_API_SCHEMA)
+        return [f] + get_flat_serializer_fields(field.child, child_prefix)
+    else:
+        name = get_prefix(prefix, field.field_name)
+        return [InputDataField(name, field)]
+
+
+def get_prefix(prefix: Optional[str], name: str) -> str:
+    if prefix and name:
+        return f"{prefix}{package_settings.NESTED_FIELD_SEPARATOR}{name}"
+    elif prefix:
+        return prefix
+    else:
+        return name
+
+
+def get_serializer_fields_with_error_codes(
+    serializer_fields: "List[InputDataField]",
+) -> "List[InputDataField]":
+    fields_with_error_codes = []
+    for sfield in serializer_fields:
+        if error_codes := get_serializer_field_error_codes(sfield.field, sfield.name):
+            sfield.error_codes = error_codes
+            fields_with_error_codes.append(sfield)
+
+    # add error codes that correspond to unique together and unique for date validators
+    sfields_with_unique_together_validators = [
+        sfield
+        for sfield in fields_with_error_codes
+        if is_basic_serializer(sfield.field)
+        and has_validator(sfield.field, UniqueTogetherValidator)
+    ]
+    add_unique_together_error_codes(
+        sfields_with_unique_together_validators, fields_with_error_codes
+    )
+
+    sfields_with_unique_for_validators = [
+        sfield
+        for sfield in fields_with_error_codes
+        if is_basic_serializer(sfield.field)
+        and has_validator(sfield.field, BaseUniqueForValidator)
+    ]
+    add_unique_for_error_codes(
+        sfields_with_unique_for_validators, fields_with_error_codes
+    )
+
+    return fields_with_error_codes
+
+
+def get_serializer_field_error_codes(field: serializers.Field, attr: str) -> Set[str]:
+    if field.read_only or isinstance(field, serializers.HiddenField):
+        return set()
+
+    error_codes = set()
+    if field.required:
+        error_codes.add("required")
+    if not field.allow_null:
+        error_codes.add("null")
+    if hasattr(field, "allow_blank") and not field.allow_blank:
+        error_codes.add("blank")
+    if getattr(field, "max_digits", None) is not None:
+        error_codes.add("max_digits")
+    if getattr(field, "decimal_places", None) is not None:
+        error_codes.add("max_decimal_places")
+    if getattr(field, "max_whole_digits", None) is not None:
+        error_codes.add("max_whole_digits")
+    if isinstance(field, serializers.DateTimeField):
+        field_timezone = getattr(field, "timezone", field.default_timezone())
+        if field_timezone is not None:
+            error_codes.update(["overflow", "make_aware"])
+    if (hasattr(field, "allow_empty") and not field.allow_empty) or (
+        hasattr(field, "allow_empty_file") and not field.allow_empty_file
+    ):
+        error_codes.add("empty")
+    if isinstance(field, serializers.FileField) and field.max_length is not None:
+        error_codes.add("max_length")
+    if isinstance(field, serializers.IPAddressField) and field.protocol in (
+        "both",
+        "ipv6",
+    ):
+        error_codes.add("invalid")
+
+    # identify error codes based on DRF and django built-in validators
+    error_codes.update(get_error_codes_from_validators(field))
+    if has_validator(field, UniqueValidator):
+        error_codes.add("unique")
+    if has_validator(field, ProhibitSurrogateCharactersValidator):
+        error_codes.add(ProhibitSurrogateCharactersValidator.code)
+
+    error_codes_with_specific_conditions = [
+        "required",
+        "null",
+        "blank",
+        "max_length",
+        "min_length",
+        "max_value",
+        "min_value",
+        "max_digits",
+        "max_decimal_places",
+        "max_whole_digits",
+        "overflow",
+        "make_aware",
+        "empty",
+        # for slug field, "invalid_unicode" is added to error_messages but it is
+        # not set as the validator code. "invalid" is the code used instead.
+        "invalid_unicode",
+    ]
+    fields_where_invalid_is_enforced_by_validators = (
+        serializers.EmailField,
+        serializers.RegexField,
+        serializers.SlugField,
+        serializers.URLField,
+        serializers.IPAddressField,
+    )
+    if isinstance(field, fields_where_invalid_is_enforced_by_validators):
+        # the "invalid" error code is enforced by a validator and is also added
+        # to error messages, so it should not be added automatically to error codes
+        error_codes_with_specific_conditions.append("invalid")
+
+    remaining_error_codes = set(field.error_messages).difference(
+        error_codes_with_specific_conditions
+    )
+    error_codes.update(remaining_error_codes)
+
+    # for top-level (as opposed to nested) serializer non_field_errors,
+    # "required" and "null" errors are not raised
+    if attr == drf_settings.NON_FIELD_ERRORS_KEY:
+        error_codes = set(error_codes).difference(["required", "null"])
+
+    # for ManyRelatedFields, add the error codes from the child_relation
+    # to the parent error codes. That's because DRF raises child_relation
+    # errors as if raised by the parent (which is a different behavior
+    # from ListSerializer and ListField). For example, ManyRelatedField
+    # would return the errors like this:
+    # {'zones': [ErrorDetail(string='Invalid pk "0" - object does not exist.', code='does_not_exist')]}
+    # while ListField returns them like this:
+    # {'zones': {0: [ErrorDetail(string='A valid integer is required.', code='invalid')]}}
+    if isinstance(field, serializers.ManyRelatedField):
+        # required and null are added depending on the ManyRelatedField definition
+        child_error_codes = set(field.child_relation.error_messages).difference(
+            ["required", "null"]
+        )
+        error_codes.update(child_error_codes)
+
+    return error_codes
+
+
+def add_unique_together_error_codes(
+    sfields_with_unique_together_validators, sfields_with_error_codes
+):
+    for sfield in sfields_with_unique_together_validators:
+        sfield.error_codes.add("unique")
+        unique_together_validators = [
+            validator
+            for validator in sfield.field.validators
+            if isinstance(validator, UniqueTogetherValidator)
+        ]
+        # fields involved in a unique together constraint have an implied
+        # "required" state, so we're adding the "required" error code to them
+        implicitly_required_fields = set()
+        for validator in unique_together_validators:
+            implicitly_required_fields.update(validator.fields)
+        for field in implicitly_required_fields:
+            add_error_code(sfield.name, field, "required", sfields_with_error_codes)
+
+
+def add_unique_for_error_codes(
+    sfields_with_unique_for_validators, sfields_with_error_codes
+):
+    for sfield in sfields_with_unique_for_validators:
+        unique_for_validators = [
+            validator
+            for validator in sfield.field.validators
+            if isinstance(validator, BaseUniqueForValidator)
+        ]
+        for v in unique_for_validators:
+            add_error_code(
+                sfield.name, v.date_field, "required", sfields_with_error_codes
+            )
+            add_error_code(sfield.name, v.field, "required", sfields_with_error_codes)
+            add_error_code(sfield.name, v.field, "unique", sfields_with_error_codes)
+
+
+def add_error_code(attr, field_name, error_code, sfields):
+    """
+    To add the error code to the right serializer field, we need to
+    determine the full field name taking into account nested serializers.
+    attr ends with drf_settings.NON_FIELD_ERRORS_KEY, so we remove that
+    and replace it with the field_name.
+    """
+    parts = attr.split(package_settings.NESTED_FIELD_SEPARATOR)
+    parts[-1] = field_name
+    full_field_name = package_settings.NESTED_FIELD_SEPARATOR.join(parts)
+
+    for sfield in sfields:
+        if sfield.name == full_field_name:
+            sfield.error_codes.add(error_code)
+            break
+
+
+def get_filter_forms(view: APIView, filter_backends: list) -> List[forms.Form]:
+    filter_forms = []
+    for backend in filter_backends:
+        model = get_view_model(view)
+        if not model:
+            continue
+        filterset = backend.get_filterset(view.request, model.objects.none(), view)
+        if filterset:
+            filter_forms.append(filterset.form)
+    return filter_forms
+
+
+def get_form_fields_with_error_codes(form: forms.Form) -> "List[InputDataField]":
+    data_fields = []
+    for field_name, field in form.fields.items():
+        error_codes = set()
+        fields = get_form_fields(field)
+        for f in fields:
+            error_codes.update(get_form_field_error_codes(f))
+        if error_codes:
+            data_fields.append(InputDataField(field_name, field, error_codes))
+    return data_fields
+
+
+def get_form_fields(field: Union[forms.Field, List[forms.Field]]) -> List[forms.Field]:
+    if not field:
+        return []
+
+    if isinstance(field, list):
+        first, *rest = field
+        return get_form_fields(first) + get_form_fields(rest)
+    elif isinstance(field, (forms.ComboField, forms.MultiValueField)):
+        return [field] + get_form_fields(field.fields)
+    else:
+        return [field]
+
+
+def get_form_field_error_codes(field: forms.Field) -> Set[str]:
+    if field.disabled:
+        return set()
+
+    error_codes = set()
+    if field.required:
+        error_codes.add("required")
+    if isinstance(field, forms.FileField) and field.max_length is not None:
+        error_codes.add("max_length")
+    if isinstance(field, forms.FileField) and not field.allow_empty_file:
+        error_codes.add("empty")
+    if isinstance(field, forms.GenericIPAddressField):
+        # because to_python calls clean_ipv6_address which can raise an error
+        # with this code
+        error_codes.add("invalid")
+
+    # add the error codes of built-in django validators
+    error_codes.update(get_error_codes_from_validators(field))
+
+    # add the error codes defined in error_messages after excluding the ones
+    # that are conditionally raised
+    error_codes_with_specific_conditions = ["required", "max_length", "empty"]
+    remaining_error_codes = set(field.error_messages).difference(
+        error_codes_with_specific_conditions
+    )
+    error_codes.update(remaining_error_codes)
+
+    # the "missing" error code is defined but never used by FileField
+    # the "incomplete" error code is not used when raising the related
+    # ValidationError in forms.MultiValueField
+    return error_codes.difference(["missing", "incomplete"])
+
+
+def has_validator(field: Union[serializers.Field, forms.Field], validator):
+    return any(isinstance(v, validator) for v in field.validators)
+
+
+def get_error_codes_from_validators(
+    field: Union[serializers.Field, forms.Field]
+) -> Set[str]:
+    error_codes = set()
+    validators = [
+        MinLengthValidator,
+        MaxLengthValidator,
+        ProhibitNullCharactersValidator,
+        MaxValueValidator,
+        MinValueValidator,
+        RegexValidator,
+        EmailValidator,
+        FileExtensionValidator,
+    ]
+    for validator in validators:
+        if has_validator(field, validator):
+            error_codes.add(validator.code)
+
+    if validators := [v for v in field.validators if isinstance(v, DecimalValidator)]:
+        validator = validators[0]
+        if validator.max_digits is not None:
+            error_codes.add("max_digits")
+        if validator.decimal_places is not None:
+            error_codes.add("max_decimal_places")
+        if validator.decimal_places is not None and validator.max_digits is not None:
+            error_codes.add("max_whole_digits")
+
+    if (
+        validate_ipv4_address in field.validators
+        or validate_ipv6_address in field.validators
+        or validate_ipv46_address in field.validators
+    ):
+        error_codes.add("invalid")
+
+    return error_codes
+
+
+def get_validation_error_serializer(
+    operation_id: str, data_fields: "List[InputDataField]"
+):
+    validation_error_component_name = f"{camelize(operation_id)}ValidationError"
+    errors_component_name = f"{camelize(operation_id)}Error"
+    sub_serializers = [
+        get_error_serializer(operation_id, sfield.name, sfield.error_codes)
+        for sfield in data_fields
+    ]
+
+    class ValidationErrorSerializer(serializers.Serializer):
+        type = serializers.ChoiceField(choices=ValidationErrorEnum.choices)
+        errors = PolymorphicProxySerializer(
+            component_name=errors_component_name,
+            resource_type_field_name="attr",
+            serializers=sub_serializers,
+            many=True,
+        )
+
+        class Meta:
+            ref_name = validation_error_component_name
+
+    return ValidationErrorSerializer
+
+
+def get_error_serializer(
+    operation_id: str, attr: str, error_codes: Set[str]
+) -> Type[serializers.Serializer]:
+    attr_choices = [(attr, attr)]
+    error_code_choices = sorted(zip(error_codes, error_codes))
+    attr_with_underscores = attr.replace(package_settings.NESTED_FIELD_SEPARATOR, "_")
+    component_name = f"{camelize(operation_id)}{camelize(attr_with_underscores)}Error"
+
+    class ErrorSerializer(serializers.Serializer):
+        attr = serializers.ChoiceField(choices=attr_choices)
+        code = serializers.ChoiceField(choices=error_code_choices)
+        detail = serializers.CharField()
+
+        class Meta:
+            ref_name = component_name
+
+    return ErrorSerializer
+
+
+@dataclass
+class InputDataField:
+    name: str
+    field: Union[serializers.Field, forms.Field]
+    error_codes: Set[str] = dataclass_field(default_factory=set)
+
+
+def get_django_filter_backends(backends):
+    """determine django filter backends that raise validation errors"""
+    try:
+        from django_filters.rest_framework import DjangoFilterBackend
+    except ImportError:
+        return []
+
+    filter_backends = [filter_backend() for filter_backend in backends]
+    return [
+        backend
+        for backend in filter_backends
+        if isinstance(backend, DjangoFilterBackend) and backend.raise_exception
+    ]
+
+
+def get_error_examples():
+    """
+    error examples for media type "application/json". The main reason for
+    adding them is that they will show `"attr": null` instead of the
+    auto-generated `"attr": "string"`
+    """
+    errors = [
+        exceptions.AuthenticationFailed(),
+        exceptions.NotAuthenticated(),
+        exceptions.PermissionDenied(),
+        exceptions.NotFound(),
+        exceptions.NotAcceptable(),
+        exceptions.UnsupportedMediaType("application/json"),
+        exceptions.Throttled(),
+        exceptions.APIException(),
+    ]
+    return [get_example_from_exception(error) for error in errors]
+
+
+def get_example_from_exception(exc: exceptions.APIException):
+    if is_client_error(exc.status_code):
+        type_ = "client_error"
+    else:
+        type_ = "server_error"
+    return OpenApiExample(
+        exc.__class__.__name__,
+        value={
+            "type": type_,
+            "errors": [{"code": exc.get_codes(), "detail": exc.detail, "attr": None}],
+        },
+        response_only=True,
+        status_codes=[str(exc.status_code)],
+    )

--- a/drf_standardized_errors/settings.py
+++ b/drf_standardized_errors/settings.py
@@ -54,6 +54,11 @@ DEFAULTS: Dict = {
     # this setting is used as a common name to be used in the API schema. So, the
     # corresponding "attr" value for the previous example will be "extra_data.KEY"
     "DICT_KEY_IN_API_SCHEMA": "KEY",
+    # should be unique to error components since it is used to identify error
+    # components generated dynamically to exclude them from being processed by
+    # the postprocessing hook. This avoids raising warnings for "code" and "attr"
+    # which can have the same choices across multiple serializers.
+    "ERROR_COMPONENT_NAME_SUFFIX": "ErrorComponent",
 }
 
 IMPORT_STRINGS = ("EXCEPTION_FORMATTER_CLASS", "EXCEPTION_HANDLER_CLASS")

--- a/drf_standardized_errors/settings.py
+++ b/drf_standardized_errors/settings.py
@@ -43,6 +43,17 @@ DEFAULTS: Dict = {
     # Examples of valid values are: serializers, None (describes an empty
     # response), drf_spectacular.utils.OpenApiResponse, ...
     "ERROR_SCHEMAS": None,
+    # When there is a validation error in list serializers, the "attr" returned
+    # will be sth like "0.email", "1.email", "2.email", ... So, to describe
+    # the error codes linked to the same field in a list serializer, the field
+    # will appear in the schema with the name "INDEX.email"
+    "LIST_INDEX_IN_API_SCHEMA": "INDEX",
+    # When there is a validation error in a DictField with the name "extra_data",
+    # the "attr" returned will be sth like "extra_data.<key1>", "extra_data.<key2>",
+    # "extra_data.<key3>", ... Since the keys of a DictField are not predetermined,
+    # this setting is used as a common name to be used in the API schema. So, the
+    # corresponding "attr" value for the previous example will be "extra_data.KEY"
+    "DICT_KEY_IN_API_SCHEMA": "KEY",
 }
 
 IMPORT_STRINGS = ("EXCEPTION_FORMATTER_CLASS", "EXCEPTION_HANDLER_CLASS")


### PR DESCRIPTION
**The goal of this PR**: describe validation error response accurately. That means API consumers should be able to know which error codes are returned for each field when checking the API schema.

Here's how validation errors look in swagger UI:
[validation_error_example](https://user-images.githubusercontent.com/17159441/172224157-c5c59759-a27e-4f39-ad87-82fb9ba7ca3c.png)
[validation_error_schema](https://user-images.githubusercontent.com/17159441/172224172-b117aad2-a5cb-4172-a34a-1302f623a5a6.png)

# Usage
If you're not overridding the postprocessing hook setting from drf-spectacular, set it to
```
"POSTPROCESSING_HOOKS": ["drf_standardized_errors.openapi_hooks.postprocess_schema_enums"]
``` 
But if you're already overriding it, make sure to replace the enums postprocessing hook from drf-spectacular with the one from this package. The hook will avoid raising warnings for dynamically created error code enums per field.

---
~~Currently, that is taken care of while accounting for nested and list serializers, composite serializer fields (like ListField and DictField) as well as validation errors raised by the django filter backend.~~

~~Custom error codes are also supported as long as you follow the DRF way of doing that. That means adding the error code as key in the serializer `default_error_messages` (or directly to `self.error_messages`) and then you can call `self.fail` to raise the validation error:~~
```python
from rest_framework import serializers

class TestSerializer(serializers.Serializer):
    default_error_messages = {"custom_code": "You can't do this."}
    field1 = serializers.CharField(required=False)
    field2 = serializers.CharField(required=False)

    def validate(self, attrs):
        field1 = attrs.get("field1")
        field2 = attrs.get("field2")
        if not field1 and not field2:
            self.fail("custom_code")

        return attrs
```

~~However, using this with drf-spectacular can result in many warnings like these:~~
```
Warning #46: enum naming encountered a non-optimally resolvable collision for fields named "attr". The same name has been used for multiple choice sets in multiple components. The collision was resolved with "AttrBb3Enum". add an entry to ENUM_NAME_OVERRIDES to fix the naming.
Warning #71: enum naming encountered a non-optimally resolvable collision for fields named "code". The same name has been used for multiple choice sets in multiple components. The collision was resolved with "CodeDaaEnum". add an entry to ENUM_NAME_OVERRIDES to fix the naming.
```

~~**After [raising the above issue in drf-spectacular](https://github.com/tfranzel/drf-spectacular/issues/753)**, the recommendation was to simply deal with this special use case, so I went ahead and created a postprocessing hook that excludes error component enums from being processed (the same hook with a minor change in which enums are collected). Package users will be encouraged to use this hook instead of the one provided by drf-spectacular.~~

~~**One more item to think about:** Ability to add custom error codes to specific fields. Currently, if the package user defines a custom error the "drf way" i.e. add it to `Field.default_error_messages` or `Field.error_messages` (same for forms with django-filters), the error code will show up automatically in the error response schema. Should another way be added to _easily_ add error codes at the `AutoSchema` class level?~~

~~That's because the list of errors relative to each serializer is represented by a [PolymorphicProxySerializer](https://drf-spectacular.readthedocs.io/en/latest/drf_spectacular.html#drf_spectacular.utils.PolymorphicProxySerializer) which allows specifying multiple serializers and each of them describes the error response for one field. A sample serializer would be like this:~~
```python
from rest_framework import serializers

class Field1Serializer(serializers.Serializer):
    attr = serializers.ChoiceField(choices=[("field1", "field1")])
    code = serializers.ChoiceField(choices=[("required", "required"), ("invalid_choice", "invalid_choice")])
    detail = serializers.CharField()
```
~~The field-specific serializers are generated **dynamically** based on the operation. So, it is very likely that the "attr" or "code" choices are the same for different operations in the API. When that happens, the [postprocessing hook](https://drf-spectacular.readthedocs.io/en/latest/drf_spectacular.html#drf_spectacular.hooks.postprocess_schema_enums) from drf-spectacular sees that and raises the warnings above.~~

~~As for solutions, current options are:~~
- ~~disable the postprocessing hook from drf-spectacular: means losing its benefits~~
- rewrite it to account for dynamically generated enums: probably involves too much copy-paste from the original postprocessing hook with minor changes.
- ~~create a new postprocessing hook that calls the drf-spectacular hook after wrapping it inside a `GENERATOR_STATS.silence()`: risks losing the good-to-hear-about warnings~~
- ~~reach out to drf-spectacular maintainer to see if they're open to adding a feature to drf-spectacular that fixes this issue: maybe disable generating enums for certain fields, ...~~
