### PR TITLE
Ignore nested read-only fields

### DIFF
--- a/drf_standardized_errors/openapi_utils.py
+++ b/drf_standardized_errors/openapi_utils.py
@@ -44,7 +44,7 @@ def get_flat_serializer_fields(
     for composite fields by returning 2 fields: one for the errors linked to
     the parent field and another one for errors linked to the child field.
     """
-    if not field:
+    if not field or getattr(field, "read_only", False):
         return []
 
     field = force_instance(field)

--- a/tests/test_openapi_utils.py
+++ b/tests/test_openapi_utils.py
@@ -38,6 +38,13 @@ class CustomSerializer(serializers.Serializer):
     field4 = NestedSerializer(many=True)
 
 
+class CustomSerializerWithNestedReadOnly(serializers.Serializer):
+    field1 = serializers.CharField()
+    field2 = serializers.ListField(child=serializers.IntegerField())
+    field3 = NestedSerializer(read_only=True)
+    field4 = NestedSerializer(read_only=True, many=True)
+
+
 def test_get_flat_serializer_fields():
     fields = get_flat_serializer_fields(CustomSerializer(many=True))
     expected_fields = {
@@ -55,6 +62,19 @@ def test_get_flat_serializer_fields():
         "INDEX.field4.INDEX.nested_field1",
         "INDEX.field4.INDEX.nested_field1.KEY",
         "INDEX.field4.INDEX.nested_field2",
+    }
+    assert {field.name for field in fields} == expected_fields
+
+
+def test_get_flat_serializer_fields_with_nested_read_only():
+    """Check case when NestedSerializer is read-only with non read-only fields."""
+    fields = get_flat_serializer_fields(CustomSerializerWithNestedReadOnly(many=True))
+    expected_fields = {
+        "non_field_errors",
+        "INDEX.non_field_errors",
+        "INDEX.field1",
+        "INDEX.field2",
+        "INDEX.field2.INDEX",
     }
     assert {field.name for field in fields} == expected_fields
 


### PR DESCRIPTION
In `get_flat_serializer_fields` I added a check for `read_only` `attr` to skip since read-only fields shouldn't raise any errors

Closes #27 