### PR TITLE
fix: rollback type issue

### DIFF
--- a/drf_standardized_errors/openapi.py
+++ b/drf_standardized_errors/openapi.py
@@ -268,10 +268,10 @@ class AutoSchema(BaseAutoSchema):
         http400_serializers = {}
         if self._should_add_validation_error_response():
             serializer = self._get_serializer_for_validation_error_response()
-            http400_serializers[ValidationErrorEnum.VALIDATION_ERROR] = serializer
+            http400_serializers[ValidationErrorEnum.VALIDATION_ERROR.value] = serializer
         if self._should_add_parse_error_response():
             serializer = ParseErrorResponseSerializer
-            http400_serializers[ClientErrorEnum.CLIENT_ERROR] = serializer
+            http400_serializers[ClientErrorEnum.CLIENT_ERROR.value] = serializer
 
         return PolymorphicProxySerializer(
             component_name=component_name,

--- a/drf_standardized_errors/openapi.py
+++ b/drf_standardized_errors/openapi.py
@@ -268,10 +268,10 @@ class AutoSchema(BaseAutoSchema):
         http400_serializers = {}
         if self._should_add_validation_error_response():
             serializer = self._get_serializer_for_validation_error_response()
-            http400_serializers[ValidationErrorEnum.VALIDATION_ERROR.value] = serializer
+            http400_serializers[ValidationErrorEnum.VALIDATION_ERROR.value] = serializer  # type: ignore[attr-defined]
         if self._should_add_parse_error_response():
             serializer = ParseErrorResponseSerializer
-            http400_serializers[ClientErrorEnum.CLIENT_ERROR.value] = serializer
+            http400_serializers[ClientErrorEnum.CLIENT_ERROR.value] = serializer  # type: ignore[attr-defined]
 
         return PolymorphicProxySerializer(
             component_name=component_name,


### PR DESCRIPTION
#34 introduced a regression, where I would get a `yaml.representer.RepresenterError: ('cannot represent an object', ClientErrorEnum.CLIENT_ERROR)`, when generating the schema.

I rollbacked the removal of the `.value`: here mypy is wrong. Mypy can be corrected with `djang-stubs`, but installing it brings other mypy warnings.

If you want some help to improve the typing or other things, I'd be willing to help :) 

I hope you'll be able to make a new release soon