### PR TITLE
fix #52 - failure to send full traceback

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,9 @@ SPECTACULAR_SETTINGS = {
 - add compatibility with drf-spectacular 0.27
 - add support for django 5.0
 
+### Fixed
+- Ensure accurate traceback inclusion in 500 error emails sent to ADMINS by capturing the original exception information using `sys.exc_info()`. This fixes the issue where tracebacks were previously showing as None.
+
 ## [0.12.6] - 2023-10-25
 ### Added
 - declare support for type checking

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,7 +33,7 @@ SPECTACULAR_SETTINGS = {
 - add support for django 5.0
 
 ### Fixed
-- Ensure accurate traceback inclusion in 500 error emails sent to ADMINS by capturing the original exception information using `sys.exc_info()`. This fixes the issue where tracebacks were previously showing as None.
+- Ensure accurate traceback inclusion in 500 error emails sent to ADMINS by capturing the original exception information using `self.exc`. This fixes the issue where tracebacks were previously showing as None for `django version >= 4.1`.
 
 ## [0.12.6] - 2023-10-25
 ### Added

--- a/drf_standardized_errors/handler.py
+++ b/drf_standardized_errors/handler.py
@@ -120,10 +120,6 @@ class ExceptionHandler:
             except AttributeError:
                 request = None
             signals.got_request_exception.send(sender=None, request=request)
-
-            # Capture the original exception info
-            original_exc = sys.exc_info()
-
             if django.VERSION < (4, 1):
                 log_response(
                     "%s: %s",
@@ -131,7 +127,7 @@ class ExceptionHandler:
                     getattr(request, "path", ""),
                     response=response,
                     request=request,
-                    exc_info=original_exc,
+                    exc_info=sys.exc_info(),
                 )
             else:
                 log_response(
@@ -140,7 +136,5 @@ class ExceptionHandler:
                     getattr(request, "path", ""),
                     response=response,
                     request=request,
-                    exception=original_exc[1],
+                    exception=self.exc,
                 )
-
-            del original_exc

--- a/drf_standardized_errors/handler.py
+++ b/drf_standardized_errors/handler.py
@@ -120,6 +120,10 @@ class ExceptionHandler:
             except AttributeError:
                 request = None
             signals.got_request_exception.send(sender=None, request=request)
+
+            # Capture the original exception info
+            original_exc = sys.exc_info()
+
             if django.VERSION < (4, 1):
                 log_response(
                     "%s: %s",
@@ -127,7 +131,7 @@ class ExceptionHandler:
                     getattr(request, "path", ""),
                     response=response,
                     request=request,
-                    exc_info=sys.exc_info(),
+                    exc_info=original_exc,
                 )
             else:
                 log_response(
@@ -136,5 +140,7 @@ class ExceptionHandler:
                     getattr(request, "path", ""),
                     response=response,
                     request=request,
-                    exception=exc,
+                    exception=original_exc[1],
                 )
+
+            del original_exc


### PR DESCRIPTION
# fix #52 - failure to send full traceback
Issue - [#52](https://github.com/ghazi-git/drf-standardized-errors/issues/52)

## Description

- Captured the original exception information using `sys.exc_info()`
- Changelog updated to reflect the fixed behavior

## Tested 
- [x] localhost

> ### NOTE: Test case is missing in this PR

Please delete the options that are not relevant.

- [ ] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update