### PR TITLE
[Feature] Add option to hide 500 error details

### DIFF
--- a/drf_standardized_errors/handler.py
+++ b/drf_standardized_errors/handler.py
@@ -39,6 +39,7 @@ class ExceptionHandler:
             return None
 
         exc = self.convert_unhandled_exceptions(exc)
+        exc = self.hide_5xx_error_details(exc)
         data = self.format_exception(exc)
         self.set_rollback()
         response = self.get_response(exc, data)
@@ -78,6 +79,14 @@ class ExceptionHandler:
             return exceptions.APIException(detail=str(exc))
         else:
             return exc
+
+    def hide_5xx_error_details(
+        self, exc: exceptions.APIException
+    ) -> exceptions.APIException:
+        msg = "Internal Server Error"
+        if package_settings.HIDE_5XX_ERROR_DETAILS and is_server_error(exc.status_code):
+            return exceptions.APIException(detail=msg)
+        return exc
 
     def format_exception(self, exc: exceptions.APIException) -> dict:
         exception_formatter_class = package_settings.EXCEPTION_FORMATTER_CLASS

--- a/drf_standardized_errors/handler.py
+++ b/drf_standardized_errors/handler.py
@@ -39,7 +39,7 @@ class ExceptionHandler:
             return None
 
         exc = self.convert_unhandled_exceptions(exc)
-        exc = self.hide_5xx_error_details(exc)
+        exc = self.hide_500_error_details(exc)
         data = self.format_exception(exc)
         self.set_rollback()
         response = self.get_response(exc, data)
@@ -80,11 +80,11 @@ class ExceptionHandler:
         else:
             return exc
 
-    def hide_5xx_error_details(
+    def hide_500_error_details(
         self, exc: exceptions.APIException
     ) -> exceptions.APIException:
         msg = "Internal Server Error"
-        if package_settings.HIDE_5XX_ERROR_DETAILS and is_server_error(exc.status_code):
+        if package_settings.HIDE_500_ERROR_DETAILS and (exc.status_code == 500):
             return exceptions.APIException(detail=msg)
         return exc
 

--- a/drf_standardized_errors/settings.py
+++ b/drf_standardized_errors/settings.py
@@ -68,6 +68,7 @@ DEFAULTS: Dict[str, Any] = {
     "EXCEPTION_HANDLER_CLASS": "drf_standardized_errors.handler.ExceptionHandler",
     "EXCEPTION_FORMATTER_CLASS": "drf_standardized_errors.formatter.ExceptionFormatter",
     "ENABLE_IN_DEBUG_FOR_UNHANDLED_EXCEPTIONS": False,
+    "HIDE_5XX_ERROR_DETAILS": False,
     "NESTED_FIELD_SEPARATOR": ".",
     "ALLOWED_ERROR_STATUS_CODES": [
         "400",

--- a/drf_standardized_errors/settings.py
+++ b/drf_standardized_errors/settings.py
@@ -68,7 +68,7 @@ DEFAULTS: Dict[str, Any] = {
     "EXCEPTION_HANDLER_CLASS": "drf_standardized_errors.handler.ExceptionHandler",
     "EXCEPTION_FORMATTER_CLASS": "drf_standardized_errors.formatter.ExceptionFormatter",
     "ENABLE_IN_DEBUG_FOR_UNHANDLED_EXCEPTIONS": False,
-    "HIDE_5XX_ERROR_DETAILS": False,
+    "HIDE_500_ERROR_DETAILS": False,
     "NESTED_FIELD_SEPARATOR": ".",
     "ALLOWED_ERROR_STATUS_CODES": [
         "400",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from rest_framework.exceptions import APIException
 from rest_framework.test import APIClient, APIRequestFactory
 
 from .views import ErrorView
@@ -22,4 +23,9 @@ def exception_context(api_request):
 
 @pytest.fixture
 def exc():
-    return Exception("Internal server error.")
+    return Exception("Unhandled server error.")
+
+
+@pytest.fixture
+def server_error():
+    return APIException()

--- a/tests/test_exception_handler.py
+++ b/tests/test_exception_handler.py
@@ -48,11 +48,6 @@ def test_permission_denied_error(permission_denied_error, exception_context):
     assert error["attr"] is None
 
 
-@pytest.fixture
-def server_error():
-    return APIException()
-
-
 def test_server_error(server_error, exception_context):
     response = exception_handler(server_error, exception_context)
     assert response.status_code == 500

--- a/tests/views.py
+++ b/tests/views.py
@@ -15,7 +15,7 @@ class IntegrityErrorView(APIView):
 
 class ErrorView(APIView):
     def get(self, request, *args, **kwargs):
-        raise Exception("Internal server error.")
+        raise Exception("Unhandled server error.")
 
 
 class ShippingAddressSerializer(serializers.Serializer):


### PR DESCRIPTION
 #42 
- [x] Added setting ```HIDE_500_ERROR_DETAILS``` and set it to ```False``` by default to ensure backward compatibility
- [x] Added test for the same
- [x] Changed the "Internal server error." to "Unhandled server error."  in tests to avoid conflict between the message from ```hide_500_error_details```