### PR TITLE
fix test_openapi_utils

### DIFF
--- a/tests/test_openapi_utils.py
+++ b/tests/test_openapi_utils.py
@@ -1,8 +1,8 @@
 import sys
 from unittest import mock
 
-import pytest
 import django
+import pytest
 from django import forms
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
@@ -517,7 +517,11 @@ def test_char_fields_with_error_codes():
     assert regex.error_codes == {"invalid", "required", "null_characters_not_allowed"}
     assert uuid.error_codes == {"invalid", "required", "null_characters_not_allowed"}
     if django.VERSION >= (4, 2):
-        assert ip.error_codes == {"invalid", "null_characters_not_allowed", "max_length"}
+        assert ip.error_codes == {
+            "invalid",
+            "null_characters_not_allowed",
+            "max_length",
+        }
     else:
         assert ip.error_codes == {"invalid", "null_characters_not_allowed"}
 

--- a/tests/test_openapi_utils.py
+++ b/tests/test_openapi_utils.py
@@ -2,6 +2,7 @@ import sys
 from unittest import mock
 
 import pytest
+import django
 from django import forms
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
@@ -515,7 +516,10 @@ def test_char_fields_with_error_codes():
     assert slug.error_codes == {"invalid", "null_characters_not_allowed"}
     assert regex.error_codes == {"invalid", "required", "null_characters_not_allowed"}
     assert uuid.error_codes == {"invalid", "required", "null_characters_not_allowed"}
-    assert ip.error_codes == {"invalid", "null_characters_not_allowed"}
+    if django.VERSION >= (4, 2):
+        assert ip.error_codes == {"invalid", "null_characters_not_allowed", "max_length"}
+    else:
+        assert ip.error_codes == {"invalid", "null_characters_not_allowed"}
 
 
 class NumberForm(forms.Form):


### PR DESCRIPTION
When packaging drf-standardized-errors for Nixpkgs, I stumbled into this pytest failure:

```console
...
python3.12-drf-standardized-errors> Running phase: pytestCheckPhase
python3.12-drf-standardized-errors> Executing pytestCheckPhase
python3.12-drf-standardized-errors> pytest flags: -m pytest
python3.12-drf-standardized-errors> ============================= test session starts ==============================
python3.12-drf-standardized-errors> platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
python3.12-drf-standardized-errors> django: version: 4.2.18, settings: tests.settings (from env)
python3.12-drf-standardized-errors> rootdir: /build/source
python3.12-drf-standardized-errors> configfile: tox.ini
python3.12-drf-standardized-errors> testpaths: tests
python3.12-drf-standardized-errors> plugins: django-4.9.0
python3.12-drf-standardized-errors> collected 120 items                                                            
python3.12-drf-standardized-errors> tests/test_exception_handler.py ...........                              [  9%]
python3.12-drf-standardized-errors> tests/test_flatten_errors.py .......                                     [ 15%]
python3.12-drf-standardized-errors> tests/test_openapi.py .....................................              [ 45%]
python3.12-drf-standardized-errors> tests/test_openapi_utils.py ........................F...........         [ 75%]
python3.12-drf-standardized-errors> tests/test_openapi_validation_errors.py ........................         [ 95%]
python3.12-drf-standardized-errors> tests/test_settings.py .....                                             [100%]
python3.12-drf-standardized-errors> =================================== FAILURES ===================================
python3.12-drf-standardized-errors> ______________________ test_char_fields_with_error_codes _______________________
python3.12-drf-standardized-errors>     def test_char_fields_with_error_codes():
python3.12-drf-standardized-errors>         (char, slug, regex, uuid, ip) = get_form_fields_with_error_codes(CharForm())
python3.12-drf-standardized-errors>     
python3.12-drf-standardized-errors>         assert char.error_codes == {
python3.12-drf-standardized-errors>             "required",
python3.12-drf-standardized-errors>             "null_characters_not_allowed",
python3.12-drf-standardized-errors>             "min_length",
python3.12-drf-standardized-errors>             "max_length",
python3.12-drf-standardized-errors>         }
python3.12-drf-standardized-errors>         assert slug.error_codes == {"invalid", "null_characters_not_allowed"}
python3.12-drf-standardized-errors>         assert regex.error_codes == {"invalid", "required", "null_characters_not_allowed"}
python3.12-drf-standardized-errors>         assert uuid.error_codes == {"invalid", "required", "null_characters_not_allowed"}
python3.12-drf-standardized-errors> >       assert ip.error_codes == {"invalid", "null_characters_not_allowed"}
python3.12-drf-standardized-errors> E       AssertionError: assert {'invalid', '..._not_allowed'} == {'invalid', '..._not_allowed'}
python3.12-drf-standardized-errors> E         
python3.12-drf-standardized-errors> E         Extra items in the left set:
python3.12-drf-standardized-errors> E         'max_length'
python3.12-drf-standardized-errors> E         Use -v to get more diff
python3.12-drf-standardized-errors> tests/test_openapi_utils.py:518: AssertionError
python3.12-drf-standardized-errors> =========================== short test summary info ============================
python3.12-drf-standardized-errors> FAILED tests/test_openapi_utils.py::test_char_fields_with_error_codes - AssertionError: assert {'invalid', '..._not_allowed'} == {'invalid', '..._n...
python3.12-drf-standardized-errors> ======================== 1 failed, 119 passed in 1.91s =========================
```

Is this just an oversight or does it hint a problem on my side?